### PR TITLE
Add log prefix as param

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -15,10 +15,11 @@ var
     DEBUG: 3
   };
 
-module.exports = function log(type, message) {
+module.exports = function log(type, prefix, message) {
   var
     msgType = _.isNumber(type) ? type : TYPES.INFO,
-    tag        = chalk.gray(MODULE_NAME),
+    logPrefix = _.isUndefined(prefix) ? MODULE_NAME : prefix,
+    tag        = chalk.gray(logPrefix),
     fmtMessage = tag + ' ';
 
   message = _.isUndefined(message) && _.isString(type) ? type : undefined;

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,8 @@ var defaults = {
   port: 3000,
   host: '0.0.0.0',
   liveReload: true,
-  liveReloadPort: 35729
+  liveReloadPort: 35729,
+  logPrefix: '[metalsmith-express]'
 };
 
 var _server, _app, _options;
@@ -21,7 +22,7 @@ module.exports = function factory(options) {
   _app = express();
 
   if(_options.liveReload) {
-    log('Using connect-livereload on port: ' + chalk.cyan(_options.liveReloadPort));
+    log('Using connect-livereload on port: ' + chalk.cyan(_options.liveReloadPort), _options.logPrefix);
     _app.use(require('connect-livereload')({
       port: _options.liveReloadPort
     }));
@@ -55,16 +56,16 @@ function start(cb) {
     var
       host = _server.address().address,
       port = _server.address().port;
-      log('Express listening at ' + chalk.cyan('http://' + host + ':' + port));
+      log('Express listening at ' + chalk.cyan('http://' + host + ':' + port), _options.logPrefix);
     cb();
   });
 
   _server.on('error', function onError(err) {
     if(err.code === "EADDRINUSE") {
-      log(chalk.red("Port " + _options.port + " is already in use by another process."));
+      log(chalk.red("Port " + _options.port + " is already in use by another process."), _options.logPrefix);
     }
     else {
-      log(chalk.red(err));
+      log(chalk.red(err), _options.logPrefix);
     }
     throw err;
   });
@@ -73,7 +74,7 @@ function start(cb) {
 
 function stop(cb) {
   _server.close(function onClose() {
-    log('Express server stopped.');
+    log('Express server stopped.', _options.logPrefix);
     cb();
   });
 }


### PR DESCRIPTION
Add an option called `logPrefix` to set project name or whatever as log prefix =]
